### PR TITLE
added fixes for the generate:resource command to make it work more relia...

### DIFF
--- a/Laravel 4 Artisan.py
+++ b/Laravel 4 Artisan.py
@@ -52,8 +52,10 @@ class Laravel4ArtisanCommand(sublime_plugin.WindowCommand):
 
     def on_fields(self, fields):
         if fields != '':
+            ##Note: found that when doing resources, some issues happened, added below
             self.args.append('--fields=')
-            self.args.append(fields)
+            self.args.append('"' + fields + '""') ## When using multiple fields, we need quotes on the fields
+            self.args.append('-n') ## non-interactive
             self.on_done()
         else:
             self.on_done()


### PR DESCRIPTION
Found that when doing a generate:resources in SublimeText 3 with the latest generators it asks you if you "want" to create models.. the -n supresses that

Also found that if you do: field:type, field:type it was throwing a "Too many arguments error", so I added quotes around the fields -- this could be a user training issue as well (add " in the input field?) 
