### PR TITLE
added support for multiple fields and non-interactive

### DIFF
--- a/Laravel 4 Artisan.py
+++ b/Laravel 4 Artisan.py
@@ -52,9 +52,8 @@ class Laravel4ArtisanCommand(sublime_plugin.WindowCommand):
 
     def on_fields(self, fields):
         if fields != '':
-            ##Note: found that when doing resources, some issues happened, added below
             self.args.append('--fields=')
-            self.args.append('"' + fields + '""') ## When using multiple fields, we need quotes on the fields
+            self.args.append(fields)
             self.args.append('-n') ## non-interactive
             self.on_done()
         else:
@@ -65,8 +64,8 @@ class Laravel4ArtisanCommand(sublime_plugin.WindowCommand):
         self.on_done()
 
     def on_done(self):
-        if os.name != 'posix':
-            self.args = subprocess.list2cmdline(self.args)
+        #if os.name != 'posix':
+            #self.args = subprocess.list2cmdline(self.args).replace('"--fields', '--fields').replace('" -n', '-n').replace('\"', '"')
         try:
             self.window.run_command("exec", {
                 "cmd": self.args,

--- a/Laravel 4 Artisan.py
+++ b/Laravel 4 Artisan.py
@@ -52,8 +52,10 @@ class Laravel4ArtisanCommand(sublime_plugin.WindowCommand):
 
     def on_fields(self, fields):
         if fields != '':
+            ##Note: found that when doing resources, some issues happened, added below
             self.args.append('--fields=')
-            self.args.append(fields)
+            self.args.append('"' + fields + '""') ## When using multiple fields, we need quotes on the fields
+            self.args.append('-n') ## non-interactive
             self.on_done()
         else:
             self.on_done()


### PR DESCRIPTION
New pull request.. 

I removed the list2cmdline as it was injecting "'s that the generator command didn't expect, thus causing issues.. it was creating this command:
artisan generate:resource task "--fields= test1:string, test2:text, test3:boolean" -n
instead of 
artisan generate:resource task --fields= test1:string, test2:text, test3:boolean -n

Also added the -n flag so that it wouldn't ask you if you wanted to create a new model.. 
